### PR TITLE
Fixing class names in e2e tests

### DIFF
--- a/test/e2e/scrolling-list/scrolling-list-scenarios.html
+++ b/test/e2e/scrolling-list/scrolling-list-scenarios.html
@@ -10,7 +10,7 @@
   <div class="list-group scrollable-list"
   scrolling-list="loadMore()"
   >
-    <table class="table-2 table-hover">
+    <table class="table table--hover">
       <thead>
         <tr>
           <th class="col-sm-9">
@@ -54,7 +54,7 @@
         $scope.loadMore();
         
         $scope.scrollBottom = function() {
-          $(".scrollable-list").scrollTop($(".table-2").height());
+          $(".scrollable-list").scrollTop($(".table--hover").height());
         }
 
       }]);

--- a/test/e2e/scrolling-list/scrolling-list-scenarios.html
+++ b/test/e2e/scrolling-list/scrolling-list-scenarios.html
@@ -54,7 +54,7 @@
         $scope.loadMore();
         
         $scope.scrollBottom = function() {
-          $(".scrollable-list").scrollTop($(".table--hover").height());
+          $(".scrollable-list").scrollTop($(".table").height());
         }
 
       }]);

--- a/test/e2e/scrolling-list/scrolling-list-scenarios.js
+++ b/test/e2e/scrolling-list/scrolling-list-scenarios.js
@@ -10,7 +10,7 @@
     });
     
     it("Should load rows", function() {
-      expect(element.all(by.css(".table-2 .list-row")).count())
+      expect(element.all(by.css(".table .list-row")).count())
         .to.eventually.equal(20);      
     });
 
@@ -24,7 +24,7 @@
       });
       
       it("Should load more rows on scroll", function() {
-        expect(element.all(by.css(".table-2 .list-row")).count())
+        expect(element.all(by.css(".table .list-row")).count())
           .to.eventually.equal(40);
       });
     });
@@ -40,7 +40,7 @@
       });
 
       it("Should not load more rows on scroll", function() {
-        expect(element.all(by.css(".table-2 .list-row")).count())
+        expect(element.all(by.css(".table .list-row")).count())
           .to.eventually.equal(20);            
       });
     });
@@ -56,7 +56,7 @@
       });
 
       it("Should not load more rows on scroll", function() {
-        expect(element.all(by.css(".table-2 .list-row")).count())
+        expect(element.all(by.css(".table .list-row")).count())
           .to.eventually.equal(0);        
       });
     });    


### PR DESCRIPTION
Upon merging the last PR to master, noticed these tests were failing consistently. The class `.table-2` no longer exists, so I replaced it with `.table`.

@Rise-Vision/apps please review. Thanks!